### PR TITLE
cleanup

### DIFF
--- a/demo/imdb_demo.clj
+++ b/demo/imdb_demo.clj
@@ -1,14 +1,17 @@
 (ns imdb-demo
-  (:require [conceptual.core :as c]
-            [conceptual.schema :as s]
-            [conceptual.int-sets :as i]
-            [clojure.java.io :as io]
-            [clojure.set :as set]
-            [clojure.string :as str])
-  (:import [java.net URL]
-           [java.io File BufferedInputStream]
-           [java.util.zip GZIPInputStream]
-           [java.nio.file Files StandardCopyOption]))
+  (:require
+   [conceptual.core :as c]
+   [conceptual.alpha.debug :as debug]
+   [conceptual.schema :as s]
+   [conceptual.int-sets :as i]
+   [clojure.java.io :as io]
+   [clojure.set :as set]
+   [clojure.string :as str])
+  (:import
+   (java.net URL)
+   (java.io File)
+   (java.util.zip GZIPInputStream)
+   (java.nio.file Files StandardCopyOption)))
 
 
 ;; Let's populate conceptual with some data.
@@ -665,7 +668,7 @@
   (reset-db!)
 
   ;; dump entire db to stdout - don't use if db is too big :D
-  (c/dump)
+  (debug/dump)
 
   ;; load the ratings
   (time (load-ratings!))

--- a/demo/walkthrough.clj
+++ b/demo/walkthrough.clj
@@ -1,14 +1,7 @@
 (ns walkthrough
-  (:require [conceptual.core :as c]
-            [conceptual.schema :as s]
-            [conceptual.int-sets :as i]
-            [clojure.java.io :as io]
-            [clojure.set :as set]
-            [clojure.string :as str])
-  (:import [java.net URL]
-           [java.io File BufferedInputStream]
-           [java.util.zip GZIPInputStream]
-           [java.nio.file Files StandardCopyOption]))
+  (:require
+   [conceptual.core :as c]
+   [conceptual.alpha.debug :as debug]))
 
 ;; create a new :default db
 (c/create-db!)
@@ -17,7 +10,7 @@
 (c/db)
 
 ;; dumps db to console... only use when db is small
-(c/dump)
+(debug/dump)
 
 (c/seek 1)
 (c/seek :db/key)

--- a/src/clj/conceptual/alpha/debug.clj
+++ b/src/clj/conceptual/alpha/debug.clj
@@ -1,7 +1,9 @@
 (ns conceptual.alpha.debug
-  (:require [conceptual.core :as c]
-            [conceptual.int-sets :as i]
-            [clojure.data :as data]))
+  (:require
+   [conceptual.core :as c]
+   [conceptual.int-sets :as i]
+   [clojure.data :as data]
+   [clojure.pprint]))
 
 (defn known-keys
   "Returns all known keys that are not of the `:db` namespace."
@@ -32,3 +34,10 @@
                (seq input-only))
        {:conceptual-only-keys (into (sorted-set) conceptual-only)
         :input-only-keys (into (sorted-set) input-only)}))))
+
+
+(defn dump
+  ([] (dump (c/db)))
+  ([db]
+   (doseq [i (range (inc (c/max-id db)))]
+     (clojure.pprint/pprint (c/seek db i)))))

--- a/src/clj/conceptual/core.clj
+++ b/src/clj/conceptual/core.clj
@@ -1,11 +1,11 @@
 (ns conceptual.core
   (:refer-clojure :exclude [mapv])
-  (:require [conceptual.arrays :refer [int-array-class]]
-            [conceptual.int-sets :as i]
-            [clojure.data.int-map :as int-map]
-            [clojure.pprint])
-  (:import [conceptual.core DB DBMap IndexAggregator PersistentDB WritableDB]
-           [clojure.lang Keyword]))
+  (:require
+   [conceptual.int-sets :as i]
+   [clojure.data.int-map :as int-map])
+  (:import
+   (conceptual.core DB DBMap IndexAggregator PersistentDB WritableDB)
+   (clojure.lang Keyword)))
 
 (set! *warn-on-reflection* true)
 
@@ -58,7 +58,7 @@
    {:db/key :db/to-many-relation? :db/type Boolean :db/property? true :db/tag? true}
    {:db/key :db/to-one-relation? :db/type Boolean :db/property? true :db/tag? true}
    {:db/key :db/inverse-relation :db/type Integer :db/property? true :db/relation? true :db/to-one-relation? true}
-   {:db/key :db/ids :db/type int-array-class :db/relation? true :db/to-many-relation? true :db/property? true}
+   {:db/key :db/ids :db/type int/1 :db/relation? true :db/to-many-relation? true :db/property? true}
    {:db/key :db/fn? :db/type Boolean :db/property? true :db/tag? true}
    {:db/key :db/fn :db/type clojure.lang.IFn :db/property? true}])
 
@@ -125,7 +125,7 @@
     [ks vs]))
 
 (defn- map->undefined-keys
-  [^DB db m]
+  [db m]
   (some->> m keys (remove (partial key->id db))))
 
 (defn create-db!
@@ -183,7 +183,7 @@
   ([ks] (keys->ids (db) ks))
   ([^DB db ks]
    (cond
-     (instance? int-array-class ks) ks
+     (instance? int/1 ks) ks
      (or (sequential? ks)
          (set? ks)) (i/map (partial key->id db) ks))))
 
@@ -196,33 +196,25 @@
      (when (keyword? key)
        (.getKeys db ^int (key->id db key))))))
 
-;; TODO: reconcile this with normalize-ids, probably can remove
-(defn ^:deprecated ordered-ids
-  "Like keys->ids but does NOT eliminate duplicates or sort. This is useful
-  for projections where the order of the projection matters."
-  ([ks] (ordered-ids (db) ks))
-  ([db ks]
-   (let [f (partial key->id db)]
-     (int-array (filter identity (map f ks))))))
-
 (defn normalize-ids
-  "Like keys->ids but does NOT eliminate duplicates or sort. This is useful
-  for projections where the order of the projection matters."
+  "Like `keys->ids` but does NOT eliminate duplicates or sort. This is useful
+  for projections where the order of the projection matters. Unknown keys
+  will be ignored and therefore the input count of ks may not be the same
+  as the output array length. `nil` can't be in a primitive int array."
   ([ks] (normalize-ids (db) ks))
   ([db ks]
    (cond
-     (instance? int-array-class ks) ks
+     (instance? int/1 ks) ks
      (or (sequential? ks)
-         (set? ks)) (let [f (partial key->id db)]
-                      (->> ks
-                           (map f)
-                           (filter identity)
-                           int-array)))))
+         (set? ks)) (->> ks
+                         (map (partial key->id db))
+                         (filter identity)
+                         int-array))))
 
 (defn id->key
   "Given and id returns the key."
   ([id]
-   (id->key (db) ^int id))
+   (id->key (db) id))
   ([^DB db id]
    (.getValue db ^int id ^int -key)))
 
@@ -634,12 +626,6 @@
   [& args]
   (reset! *db* (create-db!))
   (apply load-pickle! args))
-
-(defn dump
-  ([] (dump (db)))
-  ([^DB db]
-   (doseq [i (range (inc (max-id db)))]
-     (clojure.pprint/pprint (seek db i)))))
 
 (defn init!
   []

--- a/src/clj/conceptual/schema.clj
+++ b/src/clj/conceptual/schema.clj
@@ -19,14 +19,14 @@
   ([db aggr key type]
    (declare-property! db aggr key type {}))
   ([^DB db ^IndexAggregator aggr ^Keyword key type opts]
-   (c/insert! ^DB db ^IndexAggregator aggr (merge {:db/key key
-                                                   :db/type type
-                                                   :db/property? true}
-                                                  opts))))
+   (c/insert! db aggr (merge {:db/key key
+                              :db/type type
+                              :db/property? true}
+                             opts))))
 
 (defn declare-properties!
-  "Given a list of property specs of the form [key type] or [key type opts],
-   declares the set of properties."
+  "`args` is a list of property specs of the form `[key type]` or `[key type opts]`,
+   declares the set of properties. `key` is a keyword, `type` a class and `opts` a map"
   ([args]
    (c/with-aggr [aggr]
      (declare-properties! aggr args)))
@@ -34,7 +34,7 @@
    (swap! *db* declare-properties! aggr args))
   ([^DB db ^IndexAggregator aggr args]
    (reduce (fn [-db arg]
-             (apply (partial declare-property! -db aggr) arg))
+             (apply declare-property! -db aggr arg))
            db args)))
 
 (defn declare-tag!
@@ -46,14 +46,15 @@
    (declare-property! db aggr key Boolean {:db/tag? true})))
 
 (defn declare-tags!
+  "`args` is a seq of tupls ie `[[:sf/crew?] [:sf/team?]]` etc"
   ([args]
    (c/with-aggr [aggr]
      (declare-tags! ^IndexAggregator aggr args)))
   ([aggr args]
    (swap! *db* declare-tags! aggr args))
   ([^DB db ^IndexAggregator aggr args]
-   (reduce (fn [db arg]
-             (apply (partial declare-tag! db aggr) arg))
+   (reduce (fn [db [kw]]
+             (declare-tag! db aggr kw))
            db args)))
 
 (defn declare-to-one-relation!
@@ -95,7 +96,7 @@
                             (vector (first a) {:db/inverse-relation
                                                (c/value db :db/id (second a))}) a))]
      (reduce (fn [db arg]
-               (apply (partial declare-to-one-relation! db aggr) arg))
+               (apply declare-to-one-relation! db aggr arg))
              db args))))
 
 (defn declare-to-many-relations!
@@ -109,31 +110,11 @@
                             (vector (first a) {:db/inverse-relation
                                                (c/value db :db/id (second a))}) a))]
      (reduce (fn [db arg]
-               (apply (partial declare-to-many-relation! db aggr) arg))
+               (apply declare-to-many-relation! db aggr arg))
              db args))))
 
-(defn key-map
-  "Creates a map of the-key's value to id for the given set key or id.
-   Assumes the mapping is one to one."
-  ([the-set the-key] (key-map (c/db) the-set the-key))
-  ([db the-set the-key]
-   (some->> (c/ids db the-set)
-            (c/project db [the-key :db/id])
-            (into {}))))
-
-(defn multi-key-map
-  "Creates a map of the-key's value to a vector of all of the ids with that value."
-  ([the-set the-key] (multi-key-map (c/db) the-set the-key))
-  ([^DB db the-set the-key]
-   (->> the-set
-        (partial c/ids db)
-        (c/project db [the-key :db/id])
-        (group-by first)
-        (map (fn [[k v]] [k (mapv second v)]))
-        (into {}))))
-
 (defn add-inverse-relations!
-  "Given an seq of [relationKeyA inverseRelationKeyB] adds and inverse relation
+  "`args` is a seq of tupls `[relationKeyA inverseRelationKeyB]`. Adds an inverse relation
   (i.e. :db/inverse-relation) to the concept represented by inverseRelationKeyB."
   ([args]
    (c/with-aggr [aggr]
@@ -146,6 +127,28 @@
                         {:db/key k
                          :db/inverse-relation (some-> v second (partial c/valuei db :db/id))}))
            db args)))
+
+
+(defn key-map
+  "Creates a map of the-key's value to id for the given set key or id.
+   Assumes the mapping is one to one."
+  ([the-set the-key] (key-map (c/db) the-set the-key))
+  ([db the-set the-key]
+   (some->> (c/ids db the-set)
+            (c/project db [the-key :db/id])
+            (into {}))))
+
+
+(defn multi-key-map
+  "Creates a map of the-key's value to a vector of all of the ids with that value."
+  ([the-set the-key] (multi-key-map (c/db) the-set the-key))
+  ([^DB db the-set the-key]
+   (->> the-set
+        (c/ids db)
+        (c/project db [the-key :db/id])
+        (group-by first)
+        (map (fn [[k v]] [k (mapv second v)]))
+        (into {}))))
 
 #_(defn add-tag!
     "Add a tag represented by the 'tag-key' to a


### PR DESCRIPTION
* removed deprecated `ordered-ids`
* moved `dump` to `conceptual.alpha.debug` since it can potentially get you in trouble printing a large amount of data
* simplified some fn calls
* removed unnecessary type hinting